### PR TITLE
Point term sort at Settings.yml

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,11 +7,11 @@ module ApplicationHelper
       false
     end
   end
-  
+
   def app_config
     CourseReserves::Application.config
   end
-  
+
   def current_term
     Terms.current_term
   end
@@ -19,9 +19,9 @@ module ApplicationHelper
   def future_terms(*args)
     Terms.future_terms(*args)
   end
-  
+
   def sortable_term_value(value)
-    term_data = CourseReserves::Application.config.terms.find { |t| t[:term] == value } || {}
+    term_data = Settings.terms.find { |t| t[:term] == value } || {}
     term_data[:end_date]
   end
 end


### PR DESCRIPTION
Fixes a bug where `sortable_term_value` was throwing an error on the index page. 

```ruby
ActionView::Template::Error (undefined method `terms' for #<Rails::Application::Configuration:0x007feb9e3dae00>):
    43:   		</thead>
    44:   		<tbody>
    45:   			<% @reserves.each do |course| -%>
    46:   				<tr class="<%= cycle("odd", "even") -%>">
    47:   					<td data-sort='<%= sortable_term_value(course.term) %>'><%= course.term -%></td>
    48:   					<td><%= course.cid -%></td>
    49:             <%- # TODO: Create some sort of model method for the title of the course so we can fall back if there is no #desc -%>

app/helpers/application_helper.rb:24:in `sortable_term_value'
```

After #37, we no longer store terms in `CourseReserves::Application.config.terms`.