### PR TITLE
Add a configuration that allows us to block emails being sent when…

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,6 +35,8 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  config.action_mailer.delivery_method = :letter_opener
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -65,6 +65,10 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  if Settings.block_emails?
+    config.action_mailer.perform_deliveries = false
+  end
+
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,3 +1,5 @@
+block_emails?: false
+
 courseworks:
   coursexml_url: "https://bodoni.stanford.edu/coursereserves/courseXML_%{term}.xml"
 


### PR DESCRIPTION
…they otherwise would be.

(This is particularly useful to have a stage server, which runs in production, not send emails out)

Closes #60 

See also sul-dlss/shared_configs#486