### PR TITLE
Only render a Copy link for unsent reserve lists on the home page…

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -3,9 +3,12 @@ class Ability
 
   def initialize(user)
     can :manage, Reserve, editors: { sunetid: user.sunetid }
+
     can [:create, :clone], Reserve do |reserve|
       reserve.course && reserve.course.instructor_sunets.include?(user.sunetid)
     end
+
+    cannot :clone, Reserve, has_been_sent: nil
 
     return unless user.superuser?
     can :manage, :all

--- a/app/views/reserves/index.html.erb
+++ b/app/views/reserves/index.html.erb
@@ -52,7 +52,7 @@
               <% end %>
               <%= link_to reserve_terms_path(course), class: 'copy-link dialog' do %>
                 Copy <span class='sr-only'><%= "#{course.cid} - #{course.term}" %>
-              <% end %>
+              <% end if course.has_been_sent %>
             </td>
             <%- # TODO: Create some sort of model method for the title of the course so we can fall back if there is no #desc -%>
   					<td><%= course.desc -%></td>

--- a/spec/controllers/reserves_controller_spec.rb
+++ b/spec/controllers/reserves_controller_spec.rb
@@ -167,21 +167,21 @@ RSpec.describe ReservesController do
   describe "GET clone" do
     it "should allow you to clone an item if you are an existing editor" do
       allow(controller).to receive(:current_user).and_return(user)
-      r = Reserve.create(reserve_params.merge(:cid=>"CID1", :compound_key => "CID1,user_sunet", :sid => "01", :instructor_sunet_ids => "user_sunet"))
+      r = Reserve.create(reserve_params.merge(:cid=>"CID1", :compound_key => "CID1,user_sunet", :sid => "01", :instructor_sunet_ids => "user_sunet", :has_been_sent => true))
       r.save!
       get :clone, :params => { :id => r.id, :term => Terms.future_terms.first }
       expect(response).to redirect_to(edit_reserve_path((r[:id] + 1).to_s))
     end
     it "should allow you to clone an item if you are an super user" do
       allow(controller).to receive_messages(current_user: superuser)
-      r = Reserve.create(reserve_params.merge(:cid=>"CID1", :sid => "01", :compound_key => "CID1,user_sunet", :instructor_sunet_ids => "user_sunet"))
+      r = Reserve.create(reserve_params.merge(:cid=>"CID1", :sid => "01", :compound_key => "CID1,user_sunet", :instructor_sunet_ids => "user_sunet", :has_been_sent => true))
       r.save!
       get :clone, :params => { :id => r.id, :term => Terms.future_terms.first }
       expect(response).to redirect_to(edit_reserve_path((r[:id] + 1).to_s))
     end
     it "should transfer editor relationships to new object" do
       allow(controller).to receive(:current_user).and_return(user)
-      r = Reserve.create(reserve_params.merge(:cid=>"CID1", :sid => "01", :compound_key => "CID1,user_sunet", :term=> "Spring 2010", :instructor_sunet_ids => "user_sunet"))
+      r = Reserve.create(reserve_params.merge(:cid=>"CID1", :sid => "01", :compound_key => "CID1,user_sunet", :term=> "Spring 2010", :instructor_sunet_ids => "user_sunet", :has_been_sent => true))
       r.save!
       get :clone, :params => { :id => r.id, :term => Terms.future_terms.first }
       expect(response).to redirect_to(edit_reserve_path((r[:id] + 1).to_s))
@@ -192,14 +192,14 @@ RSpec.describe ReservesController do
     end
     it "should redirect you to an existing course if you try to clone a course w/ the same term" do
       allow(controller).to receive(:current_user).and_return(user)
-      r = Reserve.create(reserve_params.merge(:cid=>"CID1", :sid => "01", :term=> "Spring 2010", :compound_key => "CID1,user_sunet", :instructor_sunet_ids => "user_sunet"))
+      r = Reserve.create(reserve_params.merge(:cid=>"CID1", :sid => "01", :term=> "Spring 2010", :compound_key => "CID1,user_sunet", :instructor_sunet_ids => "user_sunet", :has_been_sent => true))
       r.save!
       get :clone, :params => { :id => r.id, :term => "Spring 2010" }
       expect(response).to redirect_to(edit_reserve_path(r.id))
       expect(flash[:error]).to eq("Course reserve list already exists for this course and term.")
     end
     it "should not allow you to clone an item that you are not an editor of" do
-      r = Reserve.create(reserve_params.merge(:cid=>"CID1", :sid => "01", :compound_key => "CID1,user_sunet", :instructor_sunet_ids => "user_sunet"))
+      r = Reserve.create(reserve_params.merge(:cid=>"CID1", :sid => "01", :compound_key => "CID1,user_sunet", :instructor_sunet_ids => "user_sunet", :has_been_sent => true))
       r.save!
       expect do
         get :clone, :params => { :id => r.id, :term => Terms.future_terms.first }

--- a/spec/features/copying_reserve_spec.rb
+++ b/spec/features/copying_reserve_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'Copying a reserve list', js: true do
       cid: 'AA-272C',
       compound_key: 'AA-272C,123,456',
       term: Terms.current_term,
+      has_been_sent: true,
       instructor_sunet_ids: '123,456'
     )
   end
@@ -32,6 +33,7 @@ RSpec.describe 'Copying a reserve list', js: true do
       cid: 'AA-272C',
       compound_key: 'AA-272C,123,456',
       term: Terms.future_terms.first,
+      has_been_sent: true,
       instructor_sunet_ids: '123,456'
     )
 
@@ -48,5 +50,21 @@ RSpec.describe 'Copying a reserve list', js: true do
       expect(page).to have_content("#{Terms.future_terms.first} (reserve list already exists)")
       expect(page).to have_css('a', text: Terms.future_terms.last)
     end
+  end
+
+  it 'does not present a copy link for a reserve that has not been sent' do
+    reserve = Reserve.last
+    reserve.has_been_sent = false
+    reserve.save
+
+    visit '/'
+
+    within(first('#my-reserves tbody tr')) do
+      expect(page).not_to have_link('Copy')
+
+      click_link 'Edit'
+    end
+
+    expect(page).not_to have_link 'Copy this list for a new quarter'
   end
 end


### PR DESCRIPTION
…(and enforce in ability).

This mimics the current behavior on the request form.

<img width="395" alt="screen shot 2018-03-02 at 3 22 38 pm" src="https://user-images.githubusercontent.com/5402927/36926602-8fdbe22c-1e2d-11e8-8e4c-439f5f22c387.png">
