### PR TITLE
A couple of updates to the form to match old styles/behavior

### DIFF
--- a/app/assets/stylesheets/modules/request.scss
+++ b/app/assets/stylesheets/modules/request.scss
@@ -28,7 +28,7 @@ th.delete {
 
 .num_copies { width: 10ch; }
 
-#libraries { width: 25ch; }
+#libraries { width: 35ch; }
 
 table.changed {
   border-left: 2px solid $red;

--- a/app/assets/stylesheets/modules/request.scss
+++ b/app/assets/stylesheets/modules/request.scss
@@ -30,6 +30,11 @@ th.delete {
 
 #libraries { width: 35ch; }
 
+.sent_date {
+  color: $red;
+  font-size: 1.2em;
+}
+
 table.changed {
   border-left: 2px solid $red;
   border-right: 2px solid $red;

--- a/app/views/reserves/_reserves_form.html.erb
+++ b/app/views/reserves/_reserves_form.html.erb
@@ -55,9 +55,9 @@
     <% end %>
 
 		<div class="section">
-		  <label for="libraries" class="required">Send request to</label>
-			<select id="libraries" name="reserve[library]" class="form-control" autocomplete="off">
-				<option>(select library)</option>
+		  <label for="libraries" class="required">Send request to <span aria-hidden="true" class="badge badge-warning text-white">Required</span></label>
+			<select required id="libraries" name="reserve[library]" class="form-control ml-4" autocomplete="off">
+				<option disabled selected hidden value="">(select library)</option>
 				<% Settings.reserve_libraries.each do |code, library| %>
 					<option value="<%= code -%>" <%= "selected='selected'" if @reserve.library.to_s == code.to_s -%> ><%= library -%></option>
 				<% end %>

--- a/app/views/reserves/_reserves_form.html.erb
+++ b/app/views/reserves/_reserves_form.html.erb
@@ -28,7 +28,7 @@
   		<input type="hidden" name="reserve[instructor_names]" value="<%= @reserve.instructor_names if (@reserve and @reserve.instructor_names) -%>" />
 		<%- end -%>
 
-		<div class="section">
+		<div class="section mb-3">
 			When should these items be reserved?
 			<div id="reserve-timing" class="ml-4">
 			  <%- if @reserve and @reserve.has_been_sent -%>
@@ -48,9 +48,9 @@
 
     <% if @reserve.has_been_sent %>
       <div class="section mb-3">
-        <p class="sent_date">Request sent <%= @reserve.sent_date %></p>
+        <div class="sent_date">Request sent <%= @reserve.sent_date %></div>
 
-        <%= link_to('Copy this list for a new quarter', reserve_terms_path(@reserve), class: 'dialog active-button') %>
+        <%= link_to('Copy this list for a new quarter', reserve_terms_path(@reserve), class: 'btn btn-cardinal-red', data: { modal: 'trigger' }) %>
       </div>
     <% end %>
 


### PR DESCRIPTION
This PR adds HTML5 required field validation for the Library select and changes the initial option/placeholder behavior a bit (to facilitate that required behavior).

## Before (pre-bootstrap for reference)
<img width="759" alt="before-before" src="https://user-images.githubusercontent.com/96776/87620785-4880fa00-c6d4-11ea-8f7f-f983b3ee28a5.png">

## Before (post-bootstrap)
<img width="768" alt="before" src="https://user-images.githubusercontent.com/96776/87620779-44ed7300-c6d4-11ea-9a55-accbaaedda49.png">

## After this PR
<img width="757" alt="after" src="https://user-images.githubusercontent.com/96776/87620784-47e86380-c6d4-11ea-86d1-b4d912d06b22.png">


