### PR TITLE
Update placeholder/disabled input styles

### DIFF
--- a/app/assets/stylesheets/identity/bootstrap-variables.scss
+++ b/app/assets/stylesheets/identity/bootstrap-variables.scss
@@ -45,3 +45,4 @@ $breadcrumb-bg: transparent;
 $headings-font-weight: 100;
 $nav-link-padding-y: 0.35rem;
 $navbar-padding-y: 1.1rem;
+$input-placeholder-color: #707070;

--- a/app/assets/stylesheets/identity/bootstrap-variables.scss
+++ b/app/assets/stylesheets/identity/bootstrap-variables.scss
@@ -46,3 +46,4 @@ $headings-font-weight: 100;
 $nav-link-padding-y: 0.35rem;
 $navbar-padding-y: 1.1rem;
 $input-placeholder-color: #707070;
+$input-disabled-bg: $su-fog;


### PR DESCRIPTION
Closes #262 

## Disabled Input (before)
<img width="466" alt="disabled-input-before" src="https://user-images.githubusercontent.com/96776/87837160-776bad00-c847-11ea-88ef-061481cebe0d.png">

## Disabled Input (after)
<img width="468" alt="disabled-input-after" src="https://user-images.githubusercontent.com/96776/87837163-789cda00-c847-11ea-8f9d-3495a96cb9db.png">

## Placeholder (before)
<img width="463" alt="placeholder-before" src="https://user-images.githubusercontent.com/96776/87837164-789cda00-c847-11ea-9109-5c5fc712c274.png">

## Placeholder (after
<img width="463" alt="placeholder-after" src="https://user-images.githubusercontent.com/96776/87837165-79357080-c847-11ea-9b08-09d8094e5552.png">
