### PR TITLE
adding cert and key file to linked files 

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -28,7 +28,7 @@ set :honeybadger_env, fetch(:stage)
 # set :pty, true
 
 # Default value for :linked_files is []
-set :linked_files, %w{config/database.yml config/secrets.yml config/honeybadger.yml}
+set :linked_files, %w{config/database.yml config/secrets.yml config/honeybadger.yml config/sul-harvester.cert config/sul-harvester.key}
 
 # Default value for linked_dirs is []
 set :linked_dirs, %w{log config/settings lib/course_work_xml tmp/pids tmp/cache tmp/sockets vendor/bundle public/system}


### PR DESCRIPTION
The CourseApi code requires sul-harvester.key and sul-harvester.cert to make the MaIS API requests. The files are available (on stage) in the shared configs directory. 