### PR TITLE
Adding course_work_content directory 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,9 @@ coverage
 # Ignoring vendorized gems
 /vendor/bundle
 
-# Ignoring CourseWork XML
+# Ignoring CourseWork XML and JSON
 /lib/course_work_xml/*.xml
+/lib/course_work_content/*.json
 config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -31,7 +31,7 @@ set :honeybadger_env, fetch(:stage)
 set :linked_files, %w{config/database.yml config/secrets.yml config/honeybadger.yml config/sul-harvester.cert config/sul-harvester.key}
 
 # Default value for linked_dirs is []
-set :linked_dirs, %w{log config/settings lib/course_work_xml tmp/pids tmp/cache tmp/sockets vendor/bundle public/system}
+set :linked_dirs, %w{log config/settings lib/course_work_xml lib/course_work_content tmp/pids tmp/cache tmp/sockets vendor/bundle public/system}
 
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }

--- a/lib/course_work_content/.gitignore
+++ b/lib/course_work_content/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
The XML from registry harvester is currently stored in course_work_xml.  The new fetch_courses rake task will use the MaIS APIs to write to the course_work_content directory.  Ensuring the directory exists to be written to, and following the pattern of ignoring all the JSON files in this directory for git.  Updating both main .gitignore and adding a .gitignore to the directory as well.  (If only one of these approaches is needed, please let me know.)