### PR TITLE
Removing duplicate instructors across meetings for same section

### DIFF
--- a/app/services/course_api.rb
+++ b/app/services/course_api.rb
@@ -145,13 +145,14 @@ class CourseApi
     # The same course request can return cross listed courses, so we will need to get a specific id
     course_response.xpath("//class[@id='#{request_class_id}']//section[.//instructor]").each do |section|
       section_id = section[:id]
-      instructors = []
+      # We do not want to duplicate instructor names even if multiple meetings have same instructor
+      instructor_sunets = {}
       section.xpath(".//instructor/person").each do |person|
         sunetid = person[:sunetid]
         name = person.text
-        instructors << { sunet: sunetid, name: name }
+        instructor_sunets[sunetid] = name unless instructor_sunets.key?(sunetid)
       end
-      sections << { sid: section_id, instructors: instructors }
+      sections << { sid: section_id, instructors: instructor_sunets.map { |k, v| { sunet: k, name: v } } }
     end
     sections
   end


### PR DESCRIPTION
If the XML for an individual course has the following hierarchy (the example omits other attributes and elements not related to this pull request): 
```
"<CourseClass ...> <class> <section>
<meeting number="1"><instructor> <person sunet="123"></person></instructor></meeting>
<meeting number="2"><instructor> <person sunet="123"></person></instructor></meeting>
</section></class></CourseClass>"
```

We want the information returned to not duplicate instructor names.  The xpath pattern that was being used to match against instructor names for the section returned the full list, which in this case would mean duplicating the instructor with sunet id "123".  This code update only keeps a unique set of sunet ids and related names for each section, and returns them in the information for the section.  