### PR TITLE
including new certificate setup, relying on folder for sharing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,5 @@ config/environments/*.local.yml
 /node_modules
 
 # Ignoring cert and key files
-config/*.cert
-config/*.key
+config/certs/*.cert
+config/certs/*.key

--- a/Gemfile
+++ b/Gemfile
@@ -107,3 +107,5 @@ gem 'config'
 gem 'newrelic_rpm'
 
 gem "cssbundling-rails", "~> 1.1"
+gem "ed25519"
+gem "bcrypt_pbkdf"

--- a/Gemfile
+++ b/Gemfile
@@ -83,7 +83,7 @@ group :development do
 end
 
 group :test do
-  gem 'capybara', ">= 2.15"
+  gem 'capybara', '~> 3.0'
   gem 'selenium-webdriver', '!= 3.13.0'
   gem 'simplecov', require: false
   gem 'database_cleaner'
@@ -97,15 +97,14 @@ end
 
 group :deployment do
   gem 'capistrano', '~> 3.0'
+  gem 'capistrano-rvm'
   gem 'capistrano-bundler'
   gem 'capistrano-rails'
   gem 'capistrano-passenger'
-  gem 'dlss-capistrano', '~> 3.0'
+  gem 'dlss-capistrano'
 end
 
 gem 'config'
 gem 'newrelic_rpm'
 
 gem "cssbundling-rails", "~> 1.1"
-gem "ed25519"
-gem "bcrypt_pbkdf"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,9 @@ GEM
       sshkit (>= 1.6.1, != 1.7.0)
     ast (2.4.2)
     base64 (0.2.0)
+    bcrypt_pbkdf (1.1.1)
+    bcrypt_pbkdf (1.1.1-arm64-darwin)
+    bcrypt_pbkdf (1.1.1-x86_64-darwin)
     bigdecimal (3.1.8)
     bindex (0.8.1)
     builder (3.3.0)
@@ -144,6 +147,7 @@ GEM
       capistrano-shared_configs
     docile (1.4.0)
     drb (2.2.1)
+    ed25519 (1.3.0)
     erubi (1.13.0)
     faraday (2.9.2)
       faraday-net_http (>= 2.0, < 3.2)
@@ -393,6 +397,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  bcrypt_pbkdf
   cancancan
   capistrano (~> 3.0)
   capistrano-bundler
@@ -404,6 +409,7 @@ DEPENDENCIES
   database_cleaner
   debug
   dlss-capistrano (~> 3.0)
+  ed25519
   faraday
   faraday-retry
   honeybadger

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,7 +91,7 @@ GEM
       bundler (>= 1.2.0, < 3)
       thor (~> 1.0)
     cancancan (3.6.1)
-    capistrano (3.19.0)
+    capistrano (3.19.1)
       airbrussh (>= 1.0.0)
       i18n
       rake (>= 10.0.0)
@@ -109,6 +109,9 @@ GEM
     capistrano-rails (1.6.3)
       capistrano (~> 3.1)
       capistrano-bundler (>= 1.1, < 3)
+    capistrano-rvm (0.1.2)
+      capistrano (~> 3.0)
+      sshkit (~> 1.2)
     capistrano-shared_configs (0.2.2)
     capybara (3.40.0)
       addressable
@@ -140,11 +143,13 @@ GEM
       reline (>= 0.3.8)
     deep_merge (1.2.2)
     diff-lcs (1.5.1)
-    dlss-capistrano (3.11.1)
+    dlss-capistrano (5.1.1)
+      bcrypt_pbkdf
       capistrano (~> 3.0)
       capistrano-bundle_audit (>= 0.3.0)
-      capistrano-one_time_key
+      capistrano-one_time_key (>= 0.2.0)
       capistrano-shared_configs
+      ed25519
     docile (1.4.0)
     drb (2.2.1)
     ed25519 (1.3.0)
@@ -157,7 +162,7 @@ GEM
       faraday (~> 2.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    honeybadger (5.13.0)
+    honeybadger (5.13.1)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     importmap-rails (2.0.1)
@@ -232,7 +237,7 @@ GEM
     puma (6.4.2)
       nio4r (~> 2.0)
     racc (1.8.0)
-    rack (3.1.4)
+    rack (3.1.6)
     rack-session (2.0.0)
       rack (>= 3.0.0)
     rack-test (2.1.0)
@@ -324,7 +329,7 @@ GEM
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
-    rubocop-rspec (3.0.1)
+    rubocop-rspec (3.0.2)
       rubocop (~> 1.61)
     rubocop-rspec_rails (2.30.0)
       rubocop (~> 1.61)
@@ -397,19 +402,18 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  bcrypt_pbkdf
   cancancan
   capistrano (~> 3.0)
   capistrano-bundler
   capistrano-passenger
   capistrano-rails
-  capybara (>= 2.15)
+  capistrano-rvm
+  capybara (~> 3.0)
   config
   cssbundling-rails (~> 1.1)
   database_cleaner
   debug
-  dlss-capistrano (~> 3.0)
-  ed25519
+  dlss-capistrano
   faraday
   faraday-retry
   honeybadger

--- a/app/services/course_api.rb
+++ b/app/services/course_api.rb
@@ -22,11 +22,11 @@ class CourseApi
 
   # Set up Faraday connection
   def setup_connection
-    cert_file = Rails.root.join("config/sul-harvester.cert")
-    key_file = Rails.root.join("config/sul-harvester.key")
+    cert_file = Rails.root.join("config/certs/#{Settings.courses.cert_name}.cert")
+    key_file = Rails.root.join("config/certs/#{Settings.courses.cert_name}.key")
     client_cert = OpenSSL::X509::Certificate.new File.read(cert_file)
     client_key = OpenSSL::PKey.read File.read(key_file)
-    @connection = Faraday.new(url: "https://registry.stanford.edu") do |faraday|
+    @connection = Faraday.new(url: Settings.courses.api_url) do |faraday|
       faraday.use Faraday::Response::RaiseError
       faraday.ssl[:client_cert] = client_cert
       faraday.ssl[:client_key] = client_key

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -32,10 +32,10 @@ set :honeybadger_env, fetch(:stage)
 # set :pty, true
 
 # Default value for :linked_files is []
-set :linked_files, %w{config/database.yml config/secrets.yml config/honeybadger.yml config/sul-harvester.cert config/sul-harvester.key}
+set :linked_files, %w{config/database.yml config/secrets.yml config/honeybadger.yml}
 
 # Default value for linked_dirs is []
-set :linked_dirs, %w{log config/settings lib/course_work_xml lib/course_work_content tmp/pids tmp/cache tmp/sockets vendor/bundle public/system}
+set :linked_dirs, %w{log config/settings lib/course_work_xml lib/course_work_content tmp/pids tmp/cache tmp/sockets vendor/bundle public/system config/certs}
 
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,6 +13,10 @@ block_emails?: false
 courseworks:
   coursexml_url: "https://bodoni.stanford.edu/coursereserves/courseXML_%{term}.xml"
 
+courses:
+  cert_name: sul-course-test
+  api_url: https://registry-uat.stanford.edu
+
 email:
   from: "no-reply@reserves.stanford.edu"
   reports: "searchworks-reports@lists.stanford.edu"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_01_04_174028) do
+ActiveRecord::Schema[7.1].define(version: 2022_01_04_174028) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false


### PR DESCRIPTION
Helps address #550 and #559. 
What this pull request does:

- Since the certificate file name will be different between dev/staging and production, we are now adding the config/certs directory as a shared directory and using settings to indicate the file name for the .cert and .key files.  
- The "sul-course-test" certificate relies on the UAT MAIS API URL, while the production certificate will rely on the regular/production MAIS API URL.  Settings has been updated to address this as well. 
- The code that makes the request to the API now relies on values in settings to (a) get the correct certificate and key files, and (b) use the correct MAIS API URL. 

Note, this PR will specify the production specific values for the file and API: https://github.com/sul-dlss/shared_configs/pull/2210