### PR TITLE
Update badge css

### DIFF
--- a/app/views/reserves/_reserves_item.html.erb
+++ b/app/views/reserves/_reserves_item.html.erb
@@ -13,7 +13,7 @@
 			        <p class="mb-1"><%= item['imprint'] %></p>
 			      <% end %>
 				    <% if item['online'] %>
-				      <p class="mb-1"><span class="badge badge-success" aria-hidden="true">Online</span> Full text available online</p>
+				      <p class="mb-1"><span class="badge text-bg-success" aria-hidden="true">Online</span> Full text available online</p>
 				    <% end %>
 						<%= f.hidden_field :title %>
 					<% else %>


### PR DESCRIPTION
`badge-success` was replaced by `text-bg-success` in bootstrap 5.

Fixes #642 