### PR TITLE
Disable ActiveStorage variant processor

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -36,5 +36,7 @@ module CourseReserves
       Symbol,
       Time
     ]
+
+    config.active_storage.variant_processor = :disabled
   end
 end


### PR DESCRIPTION
this avoids warnings in cron emails like this:

```
Generating image variants require the image_processing gem. Please add `gem "image_processing", "~> 1.2"` to your Gemfile or set `config.active_storage.variant_processor = :disabled`.
```